### PR TITLE
Remove deprecated lint; disable opinionated lint

### DIFF
--- a/lib/endare_lints.yaml
+++ b/lib/endare_lints.yaml
@@ -17,10 +17,9 @@ linter:
     avoid_dynamic_calls: true
     avoid_positional_boolean_parameters: true
     avoid_redundant_argument_values: true
-    avoid_returning_null_for_future: true
     avoid_returning_this: true # Cascade operator `..` is preferred.
     avoid_slow_async_io: true
-    avoid_unused_constructor_parameters: true
+    avoid_unused_constructor_parameters: false # Too opinionated.
     cancel_subscriptions: true
     close_sinks: true
     conditional_uri_does_not_exist: true


### PR DESCRIPTION
This PR disables the `avoid_unused_constructor_parameters` lint, since its opinionated.

It also removes a deprecated lint rule.