### PR TITLE
Update to Dart 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+Support Dart 3.0
+
 ## 1.0.0
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -17,15 +17,12 @@ a new version of this package will be published that incorporates those changes.
 
 Add this package to your dependencies:
 
-```shell
-flutter pub add endare_lints --dev
-```
-
-This will add `endare_lints` as a dev dependency to your project:
-
 ```yaml
 dev_dependencies:
-  endare_lints: ^1.0.0
+  endare_lints:
+    git: 
+      url: https://github.com/Endare/endare_lints
+      ref: 1.1.0
 ```
 
 Add a reference to the lint rules in your `analysis_options.yaml`:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,10 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dev_dependencies:
-  endare_lints: ^1.0.0
+  endare_lints:
+    git: 
+      url: https://github.com/Endare/endare_lints
+      ref: 1.1.0

--- a/lib/endare_lints.yaml
+++ b/lib/endare_lints.yaml
@@ -31,7 +31,7 @@ linter:
     prefer_constructors_over_static_methods: true
     prefer_final_in_for_each: true
     prefer_final_locals: true
-    prefer_mixin: false # There are still some Flutter SDK usages that get flagged. Will become obsolete in Dart 3.0
+    prefer_mixin: false # The mixin keyword is required as of Dart 3.0
     prefer_null_aware_method_calls: true
     prefer_single_quotes: true
     public_member_api_docs: false # Not enforced by the Endare style guide.
@@ -41,8 +41,10 @@ linter:
     sort_pub_dependencies: true
     sort_unnamed_constructors_first: true
     type_annotate_public_apis: true
+    type_literal_in_constant_pattern: true
     unawaited_futures: true
     unnecessary_await_in_return: true
+    unnecessary_breaks: true
     unnecessary_lambdas: true
     unnecessary_to_list_in_spreads: true
     use_colored_box: true # Flutter rule to avoid Container with only a color.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: endare_lints
 description: Recommended lints for Flutter & Dart projects tailored to the Endare BVBA code style guide.
 repository: https://github.com/Endare/endare_lints
-version: 1.0.0
+version: 1.1.0
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
This PR updates the lint package to support Dart 3 lints.

It also updates the setup guide.
This corresponds to tag version `1.1.0`.